### PR TITLE
feat: add ability to require authentication

### DIFF
--- a/changes/94.added
+++ b/changes/94.added
@@ -1,0 +1,1 @@
+Added authentication to `/api/plugins/capacity-metrics/app-metrics` URL endpoint.

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -1,4 +1,5 @@
 """Nautobot development configuration file."""
+
 import os
 import sys
 
@@ -158,3 +159,6 @@ PLUGINS_CONFIG = {
         }
     },
 }
+
+
+METRICS_AUTHENTICATED = True

--- a/docs/admin/install.md
+++ b/docs/admin/install.md
@@ -10,6 +10,10 @@ Here you will find detailed instructions on how to **install** and **configure**
 !!! note
     Please check the [dedicated page](compatibility_matrix.md) for a full compatibility matrix and the deprecation policy.
 
+## App Security
+
+The Capacity Metrics App will use the `METRICS_AUTHENTICATED` setting from Nautobot Core if set to `True` to require authentication to reach the URL endpoint. The `METRICS_AUTHENTICATED` setting was added in Nautobot 2.1.5. See [Nautobot Core Optional Settings](https://docs.nautobot.com/projects/core/en/stable/user-guide/administration/configuration/optional-settings/#metrics_authenticated) for further configuration details. If not set or set to `False`, the URL endpoint will work as it currently does without authentication.
+
 ## Install Guide
 
 !!! note
@@ -90,7 +94,6 @@ The app behavior can be controlled with the following list of settings:
 | Key     | Example | Default | Description                          |
 | ------- | ------ | -------- | ------------------------------------- |
 | `app_metrics` | `{"models": {"dcim": "Device": True}}` | `{"models": {"dcim": {"Site": True, "Rack": True, "Device": True}, "ipam": {"IPAddress": True, "Prefix": True}}, "jobs": True, "queues": True, "versions": {"basic": False, "plugins": False}` | Specifies which metrics to publish for each app. |
-
 
 ## Included Grafana Dashboard
 

--- a/nautobot_capacity_metrics/api/urls.py
+++ b/nautobot_capacity_metrics/api/urls.py
@@ -1,7 +1,15 @@
 """Django URL patterns for nautobot_capacity_metrics app."""
+
+from django.conf import settings
 from django.urls import path
+
 from . import views
 
-urlpatterns = [
-    path("app-metrics", views.AppMetricsView, name="nautobot_capacity_metrics_app_view"),
-]
+if hasattr(settings, "METRICS_AUTHENTICATED") and settings.METRICS_AUTHENTICATED:
+    urlpatterns = [
+        path("app-metrics", views.AppMetricsViewAuth.as_view(), name="nautobot_capacity_metrics_app_view"),
+    ]
+else:
+    urlpatterns = [
+        path("app-metrics", views.AppMetricsView.as_view(), name="nautobot_capacity_metrics_app_view"),
+    ]

--- a/nautobot_capacity_metrics/api/views.py
+++ b/nautobot_capacity_metrics/api/views.py
@@ -1,20 +1,21 @@
 """Django views for Prometheus metric collection and reporting."""  # pylint:  disable=too-few-public-methods
-import time
-import logging
 
-from django.conf import settings
-from django.http import HttpResponse
+import logging
+import re
+import time
 
 import prometheus_client
+from django.conf import settings
+from django.utils.encoding import smart_str
 from prometheus_client.core import CollectorRegistry, GaugeMetricFamily
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.renderers import BaseRenderer
+from rest_framework.response import Response
+from rest_framework.versioning import AcceptHeaderVersioning
+from rest_framework.views import APIView
 
 from nautobot_capacity_metrics import __REGISTRY__
-from nautobot_capacity_metrics.metrics import (
-    collect_extras_metric,
-    metric_jobs,
-    metric_models,
-    metric_versions,
-)
+from nautobot_capacity_metrics.metrics import collect_extras_metric, metric_jobs, metric_models, metric_versions
 
 logger = logging.getLogger(__name__)
 PLUGIN_SETTINGS = settings.PLUGINS_CONFIG["nautobot_capacity_metrics"]["app_metrics"]
@@ -63,10 +64,41 @@ class AppMetricsCollector:
         yield gauge
 
 
-def AppMetricsView(request):  # pylint: disable=invalid-name
-    """Exports /api/plugins/capacity-metrics/app-metrics as a Django view."""
-    registry = CollectorRegistry()
-    collector = AppMetricsCollector()
-    registry.register(collector)
-    metrics_page = prometheus_client.generate_latest(registry)
-    return HttpResponse(metrics_page, content_type=prometheus_client.CONTENT_TYPE_LATEST)
+class PrometheusVersioning(AcceptHeaderVersioning):
+    """Overwrite the Nautobot API Version with the prometheus API version. Otherwise Telegraf/Prometheus won't be able to poll due to a version mismatch."""
+
+    default_version = re.findall("version=(.+);", prometheus_client.CONTENT_TYPE_LATEST)[0]
+
+
+class PlainTextRenderer(BaseRenderer):
+    """Render API as plain text instead of JSON."""
+
+    media_type = "text/plain"
+    format = "txt"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        """Render the data."""
+        return smart_str(data, encoding=self.charset)
+
+
+class AppMetricsView(APIView):
+    """App Metrics that render properly for Prometheus collection."""
+
+    renderer_classes = [PlainTextRenderer]
+    versioning_class = PrometheusVersioning
+    permission_classes = [AllowAny]
+    serializer_class = None
+
+    def get(self, request):
+        """Exports /api/plugins/capacity-metrics/app-metrics as a Django view."""
+        registry = CollectorRegistry()
+        collector = AppMetricsCollector()
+        registry.register(collector)
+        metrics_page = prometheus_client.generate_latest(registry)
+        return Response(metrics_page, content_type=prometheus_client.CONTENT_TYPE_LATEST)
+
+
+class AppMetricsViewAuth(AppMetricsView):
+    """Require authentication to get to /api/plugins/capacity-metrics/app-metrics."""
+
+    permission_classes = [IsAuthenticated]

--- a/nautobot_capacity_metrics/tests/test_endpoints.py
+++ b/nautobot_capacity_metrics/tests/test_endpoints.py
@@ -1,9 +1,12 @@
 """Test cases for nautobot_capacity_metrics views."""
 
-from django.test import TestCase
+from django.test import RequestFactory
 from django.urls import reverse
-from rest_framework.test import APIClient
-from rest_framework import status
+from nautobot.core.testing import TestCase
+from nautobot.core.testing.api import APITestCase
+from prometheus_client.parser import text_string_to_metric_families
+
+from nautobot_capacity_metrics.api.views import AppMetricsView
 
 
 class AppMetricEndpointTests(TestCase):
@@ -11,14 +14,43 @@ class AppMetricEndpointTests(TestCase):
 
     app_metric_url = reverse("plugins-api:nautobot_capacity_metrics-api:nautobot_capacity_metrics_app_view")
 
-    def test_endpoint(self):
-        """Ensure the endpoint is working properly and is not protected by authentication."""
-        client = APIClient()
-        resp = client.get(self.app_metric_url)
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+    def query_and_parse_metrics(self):
+        response = self.client.get(self.app_metric_url)
+        self.assertHttpStatus(
+            response, 200, msg="/api/plugins/capacity-metrics/app-metrics should return a 200 HTTP status code."
+        )
+        return response.content.decode(response.charset)
 
-    def test_model_count_metrics(self):
-        """Ensure that the model count metrics work correctly."""
-        resp = self.client.get(self.app_metric_url)
-        if "TestModel" not in resp.content.decode("utf-8"):
-            self.fail("nautobot_capacity_metrics.test_models.models.TestModel does not report its count.")
+    def test_metrics_extensibility(self):
+        """Assert that the example metric from the example plugin shows up _exactly_ when the plugin is enabled."""
+        test_metric_name = "TestModel"
+        app_metrics = self.query_and_parse_metrics()
+        self.assertIn(test_metric_name, app_metrics)
+
+
+class AuthenticateMetricsTestCase(
+    APITestCase
+):  # noqa pylint: disable=too-many-ancestors,attribute-defined-outside-init
+    """Test that metric authentication works."""
+
+    def test_metrics_authentication(self):
+        """Assert that if metrics require authentication, a user not logged in gets a 403."""
+        self.client.logout()
+        headers = {}
+        response = self.client.get(
+            reverse("plugins-api:nautobot_capacity_metrics-api:nautobot_capacity_metrics_app_view"), **headers
+        )
+        self.assertHttpStatus(
+            response, 403, msg="/api/plugins/capacity-metrics/app-metrics should return a 403 HTTP status code."
+        )
+
+    def test_metrics(self):
+        """Assert that if metrics don't require authentication, a user not logged in gets a 200."""
+        self.factory = RequestFactory()
+        self.client.logout()
+
+        request = self.factory.get("/")
+        response = AppMetricsView.as_view()(request)
+        self.assertHttpStatus(
+            response, 200, msg="/api/plugins/capacity-metrics/app-metrics should return a 200 HTTP status code."
+        )

--- a/nautobot_capacity_metrics/tests/test_endpoints.py
+++ b/nautobot_capacity_metrics/tests/test_endpoints.py
@@ -14,6 +14,7 @@ class AppMetricEndpointTests(TestCase):
     app_metric_url = reverse("plugins-api:nautobot_capacity_metrics-api:nautobot_capacity_metrics_app_view")
 
     def query_and_parse_metrics(self):
+        """Query and Parse the metrics data."""
         response = self.client.get(self.app_metric_url)
         self.assertHttpStatus(
             response, 200, msg="/api/plugins/capacity-metrics/app-metrics should return a 200 HTTP status code."

--- a/nautobot_capacity_metrics/tests/test_endpoints.py
+++ b/nautobot_capacity_metrics/tests/test_endpoints.py
@@ -4,7 +4,6 @@ from django.test import RequestFactory
 from django.urls import reverse
 from nautobot.core.testing import TestCase
 from nautobot.core.testing.api import APITestCase
-from prometheus_client.parser import text_string_to_metric_families
 
 from nautobot_capacity_metrics.api.views import AppMetricsView
 


### PR DESCRIPTION
Adds the ability to require authentication to the `/api/plugins/capacity-metrics/app-metrics` endpoint using settings from Nautobot core that were added in 2.1.5.

If the setting is False or does not exist, the `/api/plugins/capacity-metrics/app-metrics` endpoint will function as it currently does (without any authentication).